### PR TITLE
Fix `returnVaultAssets` call

### DIFF
--- a/src/MultiChainClient2.ts
+++ b/src/MultiChainClient2.ts
@@ -83,6 +83,7 @@ export class MultiChainClient2 {
       }
     }
   }
+
   private generateYggAddresses(): Map<Chain, Address> {
     const addresses: Map<Chain, Address> = new Map()
     for (const [chain, client] of this.clients) {
@@ -105,19 +106,12 @@ export class MultiChainClient2 {
     const coinsTuple = this.buildCoinTuple(erc20Txs)
     const walletIndex = 0 //always 0 index
 
-    const fees = await this.ethClient.estimateCall({
-      contractAddress: routerContractAddress,
-      abi: this.routerContract,
-      funcName: 'returnVaultAssets',
-      funcParams: [routerContractAddress, asgardAddress, coinsTuple, memo],
-    })
-
     const tx = await this.ethClient.call<BigNumberish>({
       walletIndex,
       contractAddress: routerContractAddress,
       abi: this.routerContract,
       funcName: 'returnVaultAssets',
-      funcParams: [fees.toNumber(), routerContractAddress, asgardAddress, coinsTuple, memo],
+      funcParams: [routerContractAddress, asgardAddress, coinsTuple, memo],
     })
     return new BN(BigNumber.from(tx).toString())
   }
@@ -134,6 +128,7 @@ export class MultiChainClient2 {
     })
     return new BN(BigNumber.from(value).toString())
   }
+
   private buildCoinTuple(erc20Txs: RecoveryTransaction[]) {
     console.log(erc20Txs)
     const tuple = erc20Txs.map((coin) => {
@@ -153,6 +148,7 @@ export class MultiChainClient2 {
       }),
     ).toNumber()
   }
+
   private parseErc20Address(symbol: string) {
     //this needs to be lower cased since the ethers does not like the 0X prefix, it needs 0x
     return symbol.split('-')[1].toLowerCase()


### PR DESCRIPTION
- `returnVaultAssets` accepts 4 params only
```js
function returnVaultAssets(address router, address payable asgard, Coin[] memory coins, string memory memo) external payable
```

^ https://etherscan.io/address/0xc145990e84155416144c532e31f89b840ca8c2ce#code
- No need to get fees, also no need to send ETH amount in case of handling ERC20 only